### PR TITLE
Fixed missing docker repository information

### DIFF
--- a/src/main/docker/bridge/Dockerfile
+++ b/src/main/docker/bridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM arm32v7/openjdk:8-jre
 MAINTAINER Julian
 
 CMD mkdir -p /opt/service/

--- a/src/main/docker/producer/Dockerfile
+++ b/src/main/docker/producer/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM arm32v7/openjdk:8-jre
 MAINTAINER Julian
 
 CMD mkdir -p /opt/service


### PR DESCRIPTION
Corrected missing repository information, build needs to happen on an arm32v7 machine (tested on a raspberry pi) or docker buildx (untested).